### PR TITLE
Remove DynamicLibrary.executable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,20 +1,14 @@
 import 'dart:ffi';
+
 import 'package:ffi_exp/avf_audio_bindings.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:objective_c/objective_c.dart';
-
-import 'package:flutter/material.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   var fileData = await loadAsset('assets/test.mp3');
   var uint8Data = fileData.buffer.asUint8List();
-
-  // Use .executable() to look for the AVFAudio library in the app's process
-  // space.
-  //
-  // This works for AVFAudio on macOS and iOS.
-  DynamicLibrary.executable();
 
   final player = AVAudioPlayer.alloc().initWithData(
     uint8Data.toNSData(),
@@ -23,7 +17,7 @@ void main() async {
   if (player == null) {
     throw ('AVAudioPlayer failed to initialize');
   }
-  runApp(MainApp(player: player,));
+  runApp(MainApp(player: player));
 }
 
 class MainApp extends StatelessWidget {


### PR DESCRIPTION
`DynamicLibrary.executable` doesn't load any symbols, so the call isn't needed here. I verified that everything still work on iOS and macOS.

Side-note: It's not entirely clear to me how the `AVFAudio` library is loaded in this example. I would have expected an explicit `DynamicLibrary.open` call. However, since everything is working without it, something else must be triggering the load.

